### PR TITLE
Add event details modal for upcoming events

### DIFF
--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "jiti": "^2.5.1",
         "prettier": "^3.6.2",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.42.0",
@@ -4216,6 +4217,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {

--- a/Client/package.json
+++ b/Client/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jiti": "^2.5.1",
     "prettier": "^3.6.2",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.42.0",

--- a/Client/src/pages/Home/UpcomingEvents/EventDetailsModal.tsx
+++ b/Client/src/pages/Home/UpcomingEvents/EventDetailsModal.tsx
@@ -1,0 +1,75 @@
+import Event from '@entities/Event';
+import { EventTypeNames } from '@enums/EventType';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+interface EventDetailsModalProps {
+  event: Event | null;
+  onClose: () => void;
+}
+
+const formatDateTime = (dateString: string) =>
+  new Date(dateString).toLocaleString('he-IL', {
+    dateStyle: 'full',
+    timeStyle: 'short',
+  });
+
+const EventDetailsModal = ({ event, onClose }: EventDetailsModalProps) => (
+  <Dialog
+    open={Boolean(event)}
+    onClose={onClose}
+    fullWidth
+    maxWidth="sm"
+    aria-labelledby="event-details-title"
+  >
+    {event && (
+      <>
+        <DialogTitle id="event-details-title">{event.title}</DialogTitle>
+        <DialogContent dividers>
+          <Stack gap={2}>
+            <Stack>
+              <Typography variant="subtitle2" color="text.secondary">
+                סוג האירוע
+              </Typography>
+              <Typography variant="body1">{EventTypeNames[event.type]}</Typography>
+            </Stack>
+            <Stack>
+              <Typography variant="subtitle2" color="text.secondary">
+                תחילת האירוע
+              </Typography>
+              <Typography variant="body1">{formatDateTime(event.startTime)}</Typography>
+            </Stack>
+            <Stack>
+              <Typography variant="subtitle2" color="text.secondary">
+                סיום האירוע
+              </Typography>
+              <Typography variant="body1">{formatDateTime(event.endTime)}</Typography>
+            </Stack>
+            <Stack>
+              <Typography variant="subtitle2" color="text.secondary">
+                תיאור
+              </Typography>
+              <Typography variant="body1">
+                {event.description ?? 'אין תיאור זמין לאירוע זה.'}
+              </Typography>
+            </Stack>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} variant="contained" color="primary">
+            סגירה
+          </Button>
+        </DialogActions>
+      </>
+    )}
+  </Dialog>
+);
+
+export default EventDetailsModal;

--- a/Client/src/pages/Home/UpcomingEvents/UpcomingEvent.tsx
+++ b/Client/src/pages/Home/UpcomingEvents/UpcomingEvent.tsx
@@ -4,12 +4,17 @@ import { Button, Typography } from '@mui/material';
 
 interface UpcomingEventProps {
   event: Event;
+  onSelect?: (event: Event) => void;
 }
 
 const formatDate = (dateString: string) => dateString.split('T')[0].split('-').reverse().join('/');
 
-const UpcomingEvent = ({ event }: UpcomingEventProps) => (
-  <Button color="inherit" sx={{ border: '1px solid #cccccc8b', p: 2 }}>
+const UpcomingEvent = ({ event, onSelect }: UpcomingEventProps) => (
+  <Button
+    color="inherit"
+    sx={{ border: '1px solid #cccccc8b', p: 2 }}
+    onClick={() => onSelect?.(event)}
+  >
     <Row justifyContent="space-between" width="100%" alignItems="center">
       <Typography variant="h6">{event.title}</Typography>
       <Typography variant="body1">{formatDate(event.startTime)}</Typography>

--- a/Client/src/pages/Home/UpcomingEvents/index.tsx
+++ b/Client/src/pages/Home/UpcomingEvents/index.tsx
@@ -1,34 +1,51 @@
 import InfoContainer from '@components/Containers/InfoContainer';
 import Event from '@entities/Event';
 import EventIcon from '@mui/icons-material/Event';
-import { Button, Typography } from '@mui/material';
+import { Button } from '@mui/material';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import NoUpcomingEvents from './NoUpcomingEvents';
 import UpcomingEvent from './UpcomingEvent';
+import EventDetailsModal from './EventDetailsModal';
 
 interface UpcomingEventsProps {
   events: Event[];
 }
 
-const UpcomingEvents = ({ events }: UpcomingEventsProps) => (
-  <InfoContainer
-    title="אירועים קרובים"
-    icon={<EventIcon color="primary" />}
-    padding={2}
-    width="48%"
-    gap={2}
-  >
-    {events.length === 0 ? (
-      <NoUpcomingEvents />
-    ) : (
-      events.map((event) => <UpcomingEvent event={event} />)
-    )}
-    <Link to="/calendar" style={{ textDecoration: 'none', color: 'inherit' }}>
-      <Button variant="contained" color="primary" fullWidth sx={{ height: 45}}>
-        צפייה בלוח השנה המלא
-      </Button>
-    </Link>
-  </InfoContainer>
-);
+const UpcomingEvents = ({ events }: UpcomingEventsProps) => {
+  const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
+
+  const handleSelectEvent = (event: Event) => {
+    setSelectedEvent(event);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedEvent(null);
+  };
+
+  return (
+    <InfoContainer
+      title="אירועים קרובים"
+      icon={<EventIcon color="primary" />}
+      padding={2}
+      width="48%"
+      gap={2}
+    >
+      {events.length === 0 ? (
+        <NoUpcomingEvents />
+      ) : (
+        events.map((event) => (
+          <UpcomingEvent key={event.id} event={event} onSelect={handleSelectEvent} />
+        ))
+      )}
+      <Link to="/calendar" style={{ textDecoration: 'none', color: 'inherit' }}>
+        <Button variant="contained" color="primary" fullWidth sx={{ height: 45 }}>
+          צפייה בלוח השנה המלא
+        </Button>
+      </Link>
+      <EventDetailsModal event={selectedEvent} onClose={handleCloseModal} />
+    </InfoContainer>
+  );
+};
 
 export default UpcomingEvents;


### PR DESCRIPTION
## Summary
- add a modal that surfaces upcoming event details
- allow clicking an upcoming event card to open the modal with formatted information
- include the jiti dev dependency so eslint can load the TypeScript config

## Testing
- npm run lint *(fails: repository-wide react-in-jsx-scope lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd653362ec8330956c08e76f26b1cf